### PR TITLE
ADSB vertical velocity should be signed

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3074,7 +3074,7 @@
           <field type="int32_t" name="altitude">Altitude(ASL) in millimeters</field>
           <field type="uint16_t" name="heading">Course over ground in centidegrees</field>
           <field type="uint16_t" name="hor_velocity">The horizontal velocity in centimeters/second</field>
-          <field type="uint16_t" name="ver_velocity">The vertical velocity in centimeters/second, positive is up</field>
+          <field type="int16_t" name="ver_velocity">The vertical velocity in centimeters/second, positive is up</field>
           <field type="char[9]" name="callsign">The callsign, 8+null</field>
           <field type="uint8_t" name="emitter_type" enum="ADSB_EMITTER_TYPE">Type from ADSB_EMITTER_TYPE enum</field>
           <field type="uint8_t" name="tslc">Time since last communication in seconds</field>


### PR DESCRIPTION
This was fixed over a month ago (https://github.com/diydrones/ardupilot/pull/3342) but the upstream PR (https://github.com/mavlink/mavlink/pull/481) was never merged. When ardupilot went to submodules the commit was dropped in the sync/rebase/merge/fork/whateverhappensduringasubmoduleInit. This fixes that regression on this diydrones fork, would **really** appreciate this and the upstream PR to get pushed ASAP.

The hardware associated with this mavlink packet no longer communicates with ArduPilot. **This deserves an emergency Plane minor release** Copter is probably OK since their release was before the mavlink as a submodule shenanigans